### PR TITLE
Interact with mysql docker instance

### DIFF
--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,0 +1,4 @@
+FROM mysql:latest
+
+COPY init.sql /docker-entrypoint-initdb.d/
+RUN chmod 644 /docker-entrypoint-initdb.d/init.sql

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -1,0 +1,13 @@
+USE test;
+
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100),
+  email VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS products (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  product_name VARCHAR(100),
+  price DECIMAL(10,2)
+);


### PR DESCRIPTION
While we do not have the automation setup in github we can create the image and container as such:

docker build -t my-mysql .
docker run --name mysql-test --env-file .env -p 3306:3306 -d my-mysql

It assumes the following .env file
MYSQL_DATABASE=test
MYSQL_USER=test
MYSQL_PASSWORD=test
MYSQL_ROOT_PASSWORD=root
MYSQL_HOST=127.0.0.1
MYSQL_PORT=3306