### PR TITLE
SCRUM-130 File ownership and constraint deletions

### DIFF
--- a/backend/internal/handlers/file_handler.go
+++ b/backend/internal/handlers/file_handler.go
@@ -17,13 +17,20 @@ import (
 
 const fileSizeLimitMb = 20
 
-type FileHandler struct {
-	studyGroupService services.StudyGroupService
+type File struct {
+	Name    string
+	Content []byte
 }
 
-func NewFileHandler(studyGroupService services.StudyGroupService) *FileHandler {
+type FileHandler struct {
+	studyGroupService services.StudyGroupService
+	fileService       services.FileService
+}
+
+func NewFileHandler(studyGroupService services.StudyGroupService, fileService services.FileService) *FileHandler {
 	return &FileHandler{
 		studyGroupService: studyGroupService,
+		fileService:       fileService,
 	}
 }
 
@@ -84,10 +91,18 @@ func (h *FileHandler) UploadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.saveFile(file, header.Filename, chatID); err != nil {
+	err = h.saveFile(file, header.Filename, chatID)
+    if err != nil {
 		http.Error(w, "Error saving file", http.StatusInternalServerError)
 		return
 	}
+
+        err = h.createFile(header.Filename, chatID, userID)
+
+    if err != nil {
+        http.Error(w, "Error saving the file", http.StatusInternalServerError)
+        return
+    }
 
 	sendJSONResponse(w, map[string]string{"message": "File uploaded successfully"})
 }
@@ -102,7 +117,8 @@ func (h *FileHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	canDelete := h.hasDeletionRights(filename, chatID, userID)
 
 	if !canDelete {
-		http.Error(w, "Cannot delete the file", http.StatusUnauthorized)
+		http.Error(w, "Cannot delete the file", http.StatusForbidden)
+                return
 	}
 
 	err = h.deleteFileByName(filename, chatID)
@@ -202,14 +218,30 @@ func (h *FileHandler) deleteFileByName(filename string, chatID string) error {
 }
 
 func (h *FileHandler) hasDeletionRights(filename string, chatID string, userID string) bool {
-	_ = h
-	_ = filename
-	_ = chatID
-	_ = userID
-	return true
+	groupID, err := strconv.Atoi(chatID)
+	if err != nil {
+		return false
+	}
+	rights, err := h.fileService.HasDeletionRights(filename, models.StudyGroupID(groupID), models.UserID(userID))
+	if err != nil {
+		return false
+	}
+	return rights
 }
 
-type File struct {
-	Name    string
-	Content []byte
+
+func (h *FileHandler) createFile(filename string, chatID string, userID string) error {
+    groupID, err := strconv.Atoi(chatID)
+    if err != nil {
+        return err
+    }
+
+    newFile := models.File{
+        Name:    filename,
+        UserID:  models.UserID(userID),
+        GroupID: models.StudyGroupID(groupID),
+    }
+
+    _, err = h.fileService.CreateFile(newFile)
+    return err
 }

--- a/backend/internal/handlers/file_handler.go
+++ b/backend/internal/handlers/file_handler.go
@@ -92,17 +92,17 @@ func (h *FileHandler) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = h.saveFile(file, header.Filename, chatID)
-    if err != nil {
+	if err != nil {
 		http.Error(w, "Error saving file", http.StatusInternalServerError)
 		return
 	}
 
-        err = h.createFile(header.Filename, chatID, userID)
+	err = h.createFile(header.Filename, chatID, userID)
 
-    if err != nil {
-        http.Error(w, "Error saving the file", http.StatusInternalServerError)
-        return
-    }
+	if err != nil {
+		http.Error(w, "Error storing the file", http.StatusInternalServerError)
+		return
+	}
 
 	sendJSONResponse(w, map[string]string{"message": "File uploaded successfully"})
 }
@@ -118,7 +118,7 @@ func (h *FileHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 
 	if !canDelete {
 		http.Error(w, "Cannot delete the file", http.StatusForbidden)
-                return
+		return
 	}
 
 	err = h.deleteFileByName(filename, chatID)
@@ -229,19 +229,18 @@ func (h *FileHandler) hasDeletionRights(filename string, chatID string, userID s
 	return rights
 }
 
-
 func (h *FileHandler) createFile(filename string, chatID string, userID string) error {
-    groupID, err := strconv.Atoi(chatID)
-    if err != nil {
-        return err
-    }
+	groupID, err := strconv.Atoi(chatID)
+	if err != nil {
+		return err
+	}
 
-    newFile := models.File{
-        Name:    filename,
-        UserID:  models.UserID(userID),
-        GroupID: models.StudyGroupID(groupID),
-    }
+	newFile := models.File{
+		Name:    filename,
+		UserID:  models.UserID(userID),
+		GroupID: models.StudyGroupID(groupID),
+	}
 
-    _, err = h.fileService.CreateFile(newFile)
-    return err
+	_, err = h.fileService.CreateFile(newFile)
+	return err
 }

--- a/backend/internal/models/file.go
+++ b/backend/internal/models/file.go
@@ -1,0 +1,7 @@
+package models
+
+type File struct {
+	Name    string
+	UserID  UserID
+	GroupID StudyGroupID
+}

--- a/backend/internal/repositories/file_repository.go
+++ b/backend/internal/repositories/file_repository.go
@@ -57,7 +57,7 @@ func (s *SQLFileRepository) GetAllFilesByGroupID(tx *sql.Tx, groupID models.Stud
 
 func (s *SQLFileRepository) CreateFile(tx *sql.Tx, file models.File) (*models.File, error) {
 	var count int
-	err := tx.QueryRow("SELECT COUNT(1) FROM files WHERE name = ?", file.Name).Scan(&count)
+	err := tx.QueryRow("SELECT COUNT(1) FROM files WHERE name = ? AND study_group_id = ?", file.Name, file.GroupID).Scan(&count)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repositories/file_repository.go
+++ b/backend/internal/repositories/file_repository.go
@@ -1,0 +1,110 @@
+package repositories
+
+import (
+	"database/sql"
+	"errors"
+
+	"gdp8-backend/internal/models"
+)
+
+var ErrFileAlreadyExists = errors.New("file already exists")
+var ErrFileNotFound = errors.New("file not found")
+
+type FileRepository interface {
+	GetAllFiles(tx *sql.Tx) ([]models.File, error)
+	GetAllFilesByGroupID(tx *sql.Tx, groupID models.StudyGroupID) ([]models.File, error)
+	CreateFile(tx *sql.Tx, file models.File) (*models.File, error)
+	GetFileByNameAndGroupID(tx *sql.Tx, fileName string, groupID models.StudyGroupID) (*models.File, error)
+	DeleteFile(tx *sql.Tx, fileName string, groupID models.StudyGroupID) error
+}
+
+type SQLFileRepository struct {
+}
+
+func (s *SQLFileRepository) GetAllFiles(tx *sql.Tx) ([]models.File, error) {
+	rows, err := tx.Query("SELECT name, file_owner_id, study_group_id FROM files")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var files []models.File
+	for rows.Next() {
+		var file models.File
+		if err := rows.Scan(&file.Name, &file.UserID, &file.GroupID); err != nil {
+			return nil, err
+		}
+		files = append(files, file)
+	}
+	return files, rows.Err()
+}
+
+func (s *SQLFileRepository) GetAllFilesByGroupID(tx *sql.Tx, groupID models.StudyGroupID) ([]models.File, error) {
+	rows, err := tx.Query("SELECT name, file_owner_id, study_group_id FROM files WHERE study_group_id = ?", groupID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var files []models.File
+	for rows.Next() {
+		var file models.File
+		if err := rows.Scan(&file.Name, &file.UserID, &file.GroupID); err != nil {
+			return nil, err
+		}
+		files = append(files, file)
+	}
+	return files, rows.Err()
+}
+
+func (s *SQLFileRepository) CreateFile(tx *sql.Tx, file models.File) (*models.File, error) {
+	var count int
+	err := tx.QueryRow("SELECT COUNT(1) FROM files WHERE name = ?", file.Name).Scan(&count)
+	if err != nil {
+		return nil, err
+	}
+	if count > 0 {
+		return nil, ErrFileAlreadyExists
+	}
+	_, err = tx.Exec("INSERT INTO files (name, file_owner_id, study_group_id) VALUES (?, ?, ?)",
+		file.Name, file.UserID, file.GroupID)
+	if err != nil {
+		return nil, err
+	}
+	return &models.File{
+		Name:    file.Name,
+		UserID:  file.UserID,
+		GroupID: file.GroupID,
+	}, nil
+}
+
+func (s *SQLFileRepository) GetFileByNameAndGroupID(
+	tx *sql.Tx,
+	fileName string,
+	groupID models.StudyGroupID) (*models.File, error) {
+	var file models.File
+	err := tx.QueryRow(`SELECT name, file_owner_id, study_group_id
+        FROM files
+        WHERE name = ? AND study_group_id = ?`, fileName, groupID).
+		Scan(&file.Name, &file.UserID, &file.GroupID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrFileNotFound
+		}
+		return nil, err
+	}
+	return &file, nil
+}
+
+func (s *SQLFileRepository) DeleteFile(tx *sql.Tx, fileName string, groupID models.StudyGroupID) error {
+	result, err := tx.Exec("DELETE FROM files WHERE name = ? AND study_group_id = ?", fileName, groupID)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrFileNotFound
+	}
+	return nil
+}

--- a/backend/internal/repositories/file_repository.go
+++ b/backend/internal/repositories/file_repository.go
@@ -57,7 +57,11 @@ func (s *SQLFileRepository) GetAllFilesByGroupID(tx *sql.Tx, groupID models.Stud
 
 func (s *SQLFileRepository) CreateFile(tx *sql.Tx, file models.File) (*models.File, error) {
 	var count int
-	err := tx.QueryRow("SELECT COUNT(1) FROM files WHERE name = ? AND study_group_id = ?", file.Name, file.GroupID).Scan(&count)
+	err := tx.QueryRow(`SELECT COUNT(1)
+        FROM files
+        WHERE name = ? AND study_group_id = ?`,
+		file.Name, file.GroupID).Scan(&count)
+
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/routes/file_routes.go
+++ b/backend/internal/routes/file_routes.go
@@ -10,10 +10,10 @@ import (
 	"gdp8-backend/internal/services"
 )
 
-func RegisterFileRoutes(firebaseAuth *auth.Client, studyGroupService services.StudyGroupService) {
-	handler := handlers.NewFileHandler(studyGroupService)
-	// To get all files from a chat room—depending on how we change the study groups could be group id
-	// do not think is worth to have an endpoint to get a single file
+func RegisterFileRoutes(firebaseAuth *auth.Client,
+	studyGroupService services.StudyGroupService,
+	fileService services.FileService) {
+	handler := handlers.NewFileHandler(studyGroupService, fileService)
 	http.HandleFunc("GET /api/files/{chatID}", middleware.WithFirebaseAuth(firebaseAuth, handler.GetFiles))
 	http.HandleFunc("POST /api/file/delete", middleware.WithFirebaseAuth(firebaseAuth, handler.DeleteFile))
 	http.HandleFunc("POST /api/file", middleware.WithFirebaseAuth(firebaseAuth, handler.UploadFile))

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -18,19 +18,21 @@ func RegisterAllRoutes(firebaseAuth *auth.Client, txManager persistence.Transact
 	notificationRepo := repositories.SQLNotificationRepository{}
 	studySessionRepo := repositories.SQLStudySessionRepository{}
 	studySessionAvailabilityRepo := repositories.SQLStudySessionAvailabilityRepository{}
+	fileRepo := repositories.SQLFileRepository{}
 
 	userService := services.NewUserService(txManager, &userRepo)
 	moduleService := services.NewModuleService(txManager, &moduleRepo)
 	notificationService := services.NewNotificationService(txManager, &notificationRepo)
 	studyGroupService := services.NewStudyGroupService(txManager, &studyGroupRepo, notificationService)
 	studySessionService := services.NewStudySessionService(txManager, &studySessionAvailabilityRepo, &studySessionRepo)
+	fileService := services.NewFileService(txManager, &fileRepo, studyGroupService)
 
 	RegisterStudyGroupRoutes(firebaseAuth, studyGroupService, studySessionService)
 	RegisterModuleRoutes(firebaseAuth, moduleService)
 	RegisterNotificationRoutes(firebaseAuth, notificationService)
 	RegisterUserRoutes(firebaseAuth, userService)
 	RegisterChatRoutes(firebaseAuth)
-	RegisterFileRoutes(firebaseAuth, studyGroupService)
+	RegisterFileRoutes(firebaseAuth, studyGroupService, fileService)
 
 	authHandler := handlers.NewAuthHandler(firebaseAuth)
 	http.HandleFunc("/api/auth/verify", authHandler.VerifyHandler)

--- a/backend/internal/services/file_service.go
+++ b/backend/internal/services/file_service.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"database/sql"
-	"fmt"
 
 	"gdp8-backend/internal/models"
 	"gdp8-backend/internal/persistence"
@@ -50,56 +49,26 @@ func (s *fileServiceImpl) DeleteFile(fileName string, groupID models.StudyGroupI
 	})
 }
 
-// func (s *fileServiceImpl) HasDeletionRights(fileName string,
-// 	groupID models.StudyGroupID,
-// 	userID models.UserID) (bool, error) {
-// 	return persistence.WithTransaction(s.txManager, func(tx *sql.Tx) (bool, error) {
-// 		file, err := s.fileRepo.GetFileByNameAndGroupID(tx, fileName, groupID)
-// 		if err != nil {
-// 			return false, err
-// 		}
-// 		if file.UserID == userID {
-// 			return true, nil
-// 		}
-// 		group, err := s.studyGroupService.GetStudyGroupByID(groupID)
-// 		if err != nil {
-// 			return false, err
-// 		}
-// 		for _, member := range group.Members {
-// 			if member.UserID == userID && member.Role == models.RoleAdmin {
-// 				return true, nil
-// 			}
-// 		}
-// 		return false, nil
-// 	})
-// }
-
 func (s *fileServiceImpl) HasDeletionRights(fileName string,
 	groupID models.StudyGroupID,
 	userID models.UserID) (bool, error) {
 	return persistence.WithTransaction(s.txManager, func(tx *sql.Tx) (bool, error) {
 		file, err := s.fileRepo.GetFileByNameAndGroupID(tx, fileName, groupID)
 		if err != nil {
-			fmt.Printf("[HasDeletionRights] Error fetching file '%s' in group %d: %v\n", fileName, groupID, err)
 			return false, err
 		}
-		fmt.Printf("[HasDeletionRights] File '%s' fetched: owner=%s, requestedUser=%s\n", fileName, file.UserID, userID)
 		if file.UserID == userID {
-			fmt.Printf("[HasDeletionRights] User %s is the owner of file '%s'\n", userID, fileName)
 			return true, nil
 		}
 		group, err := s.studyGroupService.GetStudyGroupByID(groupID)
 		if err != nil {
-			fmt.Printf("[HasDeletionRights] Error fetching study group %d: %v\n", groupID, err)
 			return false, err
 		}
 		for _, member := range group.Members {
 			if member.UserID == userID && member.Role == models.RoleAdmin {
-				fmt.Printf("[HasDeletionRights] User %s is an admin in group %d\n", userID, groupID)
 				return true, nil
 			}
 		}
-		fmt.Printf("[HasDeletionRights] User %s does not have deletion rights for file '%s' in group %d\n", userID, fileName, groupID)
 		return false, nil
 	})
 }

--- a/backend/internal/services/file_service.go
+++ b/backend/internal/services/file_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"database/sql"
+	"fmt"
 
 	"gdp8-backend/internal/models"
 	"gdp8-backend/internal/persistence"
@@ -49,26 +50,56 @@ func (s *fileServiceImpl) DeleteFile(fileName string, groupID models.StudyGroupI
 	})
 }
 
+// func (s *fileServiceImpl) HasDeletionRights(fileName string,
+// 	groupID models.StudyGroupID,
+// 	userID models.UserID) (bool, error) {
+// 	return persistence.WithTransaction(s.txManager, func(tx *sql.Tx) (bool, error) {
+// 		file, err := s.fileRepo.GetFileByNameAndGroupID(tx, fileName, groupID)
+// 		if err != nil {
+// 			return false, err
+// 		}
+// 		if file.UserID == userID {
+// 			return true, nil
+// 		}
+// 		group, err := s.studyGroupService.GetStudyGroupByID(groupID)
+// 		if err != nil {
+// 			return false, err
+// 		}
+// 		for _, member := range group.Members {
+// 			if member.UserID == userID && member.Role == models.RoleAdmin {
+// 				return true, nil
+// 			}
+// 		}
+// 		return false, nil
+// 	})
+// }
+
 func (s *fileServiceImpl) HasDeletionRights(fileName string,
 	groupID models.StudyGroupID,
 	userID models.UserID) (bool, error) {
 	return persistence.WithTransaction(s.txManager, func(tx *sql.Tx) (bool, error) {
 		file, err := s.fileRepo.GetFileByNameAndGroupID(tx, fileName, groupID)
 		if err != nil {
+			fmt.Printf("[HasDeletionRights] Error fetching file '%s' in group %d: %v\n", fileName, groupID, err)
 			return false, err
 		}
+		fmt.Printf("[HasDeletionRights] File '%s' fetched: owner=%s, requestedUser=%s\n", fileName, file.UserID, userID)
 		if file.UserID == userID {
+			fmt.Printf("[HasDeletionRights] User %s is the owner of file '%s'\n", userID, fileName)
 			return true, nil
 		}
 		group, err := s.studyGroupService.GetStudyGroupByID(groupID)
 		if err != nil {
+			fmt.Printf("[HasDeletionRights] Error fetching study group %d: %v\n", groupID, err)
 			return false, err
 		}
 		for _, member := range group.Members {
 			if member.UserID == userID && member.Role == models.RoleAdmin {
+				fmt.Printf("[HasDeletionRights] User %s is an admin in group %d\n", userID, groupID)
 				return true, nil
 			}
 		}
+		fmt.Printf("[HasDeletionRights] User %s does not have deletion rights for file '%s' in group %d\n", userID, fileName, groupID)
 		return false, nil
 	})
 }

--- a/backend/internal/services/file_service.go
+++ b/backend/internal/services/file_service.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"database/sql"
+
+	"gdp8-backend/internal/models"
+	"gdp8-backend/internal/persistence"
+	"gdp8-backend/internal/repositories"
+)
+
+type FileService interface {
+	GetAllFilesByGroupID(groupID models.StudyGroupID) ([]models.File, error)
+	CreateFile(file models.File) (*models.File, error)
+	DeleteFile(fileName string, groupID models.StudyGroupID) error
+	HasDeletionRights(fileName string, groupID models.StudyGroupID, userID models.UserID) (bool, error)
+}
+
+type fileServiceImpl struct {
+	txManager         persistence.TransactionManager
+	fileRepo          repositories.FileRepository
+	studyGroupService StudyGroupService
+}
+
+func NewFileService(txManager persistence.TransactionManager,
+	fileRepo repositories.FileRepository,
+	studyGroupService StudyGroupService) FileService {
+	return &fileServiceImpl{
+		txManager:         txManager,
+		fileRepo:          fileRepo,
+		studyGroupService: studyGroupService,
+	}
+}
+
+func (s *fileServiceImpl) GetAllFilesByGroupID(groupID models.StudyGroupID) ([]models.File, error) {
+	return persistence.WithTransaction(s.txManager, func(tx *sql.Tx) ([]models.File, error) {
+		return s.fileRepo.GetAllFilesByGroupID(tx, groupID)
+	})
+}
+
+func (s *fileServiceImpl) CreateFile(file models.File) (*models.File, error) {
+	return persistence.WithTransaction(s.txManager, func(tx *sql.Tx) (*models.File, error) {
+		return s.fileRepo.CreateFile(tx, file)
+	})
+}
+
+func (s *fileServiceImpl) DeleteFile(fileName string, groupID models.StudyGroupID) error {
+	return persistence.WithTransactionNoReturnVal(s.txManager, func(tx *sql.Tx) error {
+		return s.fileRepo.DeleteFile(tx, fileName, groupID)
+	})
+}
+
+func (s *fileServiceImpl) HasDeletionRights(fileName string,
+	groupID models.StudyGroupID,
+	userID models.UserID) (bool, error) {
+	return persistence.WithTransaction(s.txManager, func(tx *sql.Tx) (bool, error) {
+		file, err := s.fileRepo.GetFileByNameAndGroupID(tx, fileName, groupID)
+		if err != nil {
+			return false, err
+		}
+		if file.UserID == userID {
+			return true, nil
+		}
+		group, err := s.studyGroupService.GetStudyGroupByID(groupID)
+		if err != nil {
+			return false, err
+		}
+		for _, member := range group.Members {
+			if member.UserID == userID && member.Role == models.RoleAdmin {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}

--- a/backend/migrations/create_and_seed.sql
+++ b/backend/migrations/create_and_seed.sql
@@ -189,8 +189,8 @@ CREATE TABLE IF NOT EXISTS study_sessions (
 CREATE TABLE IF NOT EXISTS files (
     name VARCHAR(255) PRIMARY KEY,
     file_owner_id VARCHAR(255) UNIQUE NOT NULL,
-    study_group_id INT not null
+    study_group_id INT not null,
 
     FOREIGN KEY (study_group_id) REFERENCES study_groups(id) ON DELETE CASCADE,
-    FOREIGN KEY (file_owner_id) REFERENCES users(id) ON DELETE RESTRICT,
+    FOREIGN KEY (file_owner_id) REFERENCES users(id) ON DELETE RESTRICT
 );

--- a/backend/migrations/create_and_seed.sql
+++ b/backend/migrations/create_and_seed.sql
@@ -185,3 +185,12 @@ CREATE TABLE IF NOT EXISTS study_sessions (
     INDEX idx_study_sessions_study_group_id (study_group_id),
     INDEX idx_study_sessions_group_id_and_end_time (study_group_id, end_time)
 );
+
+CREATE TABLE IF NOT EXISTS files (
+    name VARCHAR(255) PRIMARY KEY,
+    file_owner_id VARCHAR(255) UNIQUE NOT NULL,
+    study_group_id INT not null
+
+    FOREIGN KEY (study_group_id) REFERENCES study_groups(id) ON DELETE CASCADE,
+    FOREIGN KEY (file_owner_id) REFERENCES users(id) ON DELETE RESTRICT,
+);

--- a/backend/migrations/create_and_seed.sql
+++ b/backend/migrations/create_and_seed.sql
@@ -187,10 +187,10 @@ CREATE TABLE IF NOT EXISTS study_sessions (
 );
 
 CREATE TABLE IF NOT EXISTS files (
-    name VARCHAR(255) PRIMARY KEY,
-    file_owner_id VARCHAR(255) UNIQUE NOT NULL,
-    study_group_id INT not null,
-
+    name VARCHAR(255) NOT NULL,
+    file_owner_id VARCHAR(255) NOT NULL,
+    study_group_id INT NOT NULL,
+    PRIMARY KEY (name, study_group_id),
     FOREIGN KEY (study_group_id) REFERENCES study_groups(id) ON DELETE CASCADE,
     FOREIGN KEY (file_owner_id) REFERENCES users(id) ON DELETE RESTRICT
 );


### PR DESCRIPTION
Now files can only be deleted by the study group admin or the original uploader of the file.

Files now have a table with the db that associates them with a the user that uploaded it and the study group where the file belongs.

UploadFile now after the file is stored adds the entry in the db.

and the deletion checks does entries from the db to tell whether the user doing the deletion request is allowed.