### PR TITLE
SCRUM-151 Fix API endpoint for fetching study session availability requests (backend)

### DIFF
--- a/backend/internal/handlers/study_session_handler.go
+++ b/backend/internal/handlers/study_session_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -72,6 +73,7 @@ func (h *StudySessionHandler) GetStudySessionsByGroup(w http.ResponseWriter, r *
 
 	sessions, err := h.service.GetAllStudySessionsByStudyGroup(groupID, userID)
 	if err != nil {
+		log.Printf("Error getting study sessions for group ID %s, user ID %s: %v", groupIDString, userID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -122,6 +124,7 @@ func (h *StudySessionHandler) CreateStudySession(w http.ResponseWriter, r *http.
 
 	session, err := h.service.CreateStudySession(groupID, creatorID, details)
 	if err != nil {
+		log.Printf("Error creating study session for group ID %s, creator ID %s: %v", groupIDString, creatorID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -162,6 +165,7 @@ func (h *StudySessionHandler) UpdateStudySession(w http.ResponseWriter, r *http.
 
 	session, err := h.service.UpdateStudySession(studySessionID, details, userID)
 	if err != nil {
+		log.Printf("Error updating study session with ID %s by user %s: %v", studySessionIDString, userID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -184,6 +188,7 @@ func (h *StudySessionHandler) DeleteStudySession(w http.ResponseWriter, r *http.
 	}
 
 	if err := h.service.DeleteStudySession(studySessionID, userID); err != nil {
+		log.Printf("Error deleting study session with ID %s by user %s: %v", studySessionIDString, userID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -207,6 +212,7 @@ func (h *StudySessionHandler) GetCurrentAvailabilityRequests(w http.ResponseWrit
 
 	requests, err := h.service.GetCurrentStudySessionAvailabilityRequests(groupID, userID)
 	if err != nil {
+		log.Printf("Error getting current availability requests for group ID %s, user ID %s: %v", groupIDString, userID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -255,6 +261,7 @@ func (h *StudySessionHandler) CreateAvailabilityRequest(w http.ResponseWriter, r
 	}
 
 	if err := h.service.CreateStudySessionAvailabilityRequest(groupID, details, userID); err != nil {
+		log.Printf("Error creating availability request for group ID %s, user ID %s: %v", groupIDString, userID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -277,6 +284,7 @@ func (h *StudySessionHandler) DeleteAvailabilityRequest(w http.ResponseWriter, r
 	}
 
 	if err := h.service.DeleteStudySessionAvailabilityRequest(requestID, userID); err != nil {
+		log.Printf("Error deleting availability request with ID %s by user %s: %v", requestIDString, userID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -318,6 +326,7 @@ func (h *StudySessionHandler) UpsertAvailabilityEntries(w http.ResponseWriter, r
 	}
 
 	if err := h.service.UpsertUserAvailabilityEntries(requestID, userID, entries); err != nil {
+		log.Printf("Error updating availability entries for request ID %s by user %s: %v", requestIDString, userID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/backend/internal/repositories/study_session_availability_repository.go
+++ b/backend/internal/repositories/study_session_availability_repository.go
@@ -54,13 +54,15 @@ func (s *SQLStudySessionAvailabilityRepository) GetCurrentStudySessionAvailabili
 			return nil, fmt.Errorf("failed to scan availability request: %w", err)
 		}
 
+		requests = append(requests, request)
+	}
+
+	for _, request := range requests {
 		entries, err := s.getEntriesForRequest(tx, request.ID)
 		if err != nil {
 			return nil, err
 		}
-
 		request.Entries = entries
-		requests = append(requests, request)
 	}
 
 	if err = rows.Err(); err != nil {


### PR DESCRIPTION
- Fixed the API endpoint for fetching study session availability requests.
- Added backend logging in the study session handler.

The bug manifested itself with `GetCurrentStudySessionAvailabilityRequests` method in the `SQLStudySessionAvailabilityRepository` returning a `bad connection` error (from the MySQL driver). The problem actually had to do with executing the `getEntriesForRequest` method (which performs another SQL query) without firstly retrieving all the rows returned by the main query (`commands out of sync` - a new query cannot be executed if there are still rows to be fetched from an in-progress query).